### PR TITLE
Add Nginx Proxy Manager service

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,12 @@ Think **[webwhiteboard.com](https://webwhiteboard.com)** but on your own server.
    docker compose up --build
    ```
 
-3. **Open your browser:**
-   Navigate to `http://localhost:3000` (replace `localhost` with your server's IP or domain).
+3. **Access Nginx Proxy Manager:**
+   The compose file now includes an [Nginx Proxy Manager](https://nginxproxymanager.com/) container. Open `http://localhost:81` and log in with the default credentials to configure a new proxy host that forwards to `whiteboard:3000`.
 
-4. **Invite a friend:**
+4. **Open your browser:**
+   Navigate to `http://localhost:3000` (replace `localhost` with your server's IP or domain).
+5. **Invite a friend:**
    Share the URL. Anyone who visits can draw on the whiteboard in real time.
 
 ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,15 @@ services:
     volumes:
       - ./public:/app/public
     restart: unless-stopped
+
+  npm:
+    image: 'jc21/nginx-proxy-manager:latest'
+    container_name: npm
+    restart: unless-stopped
+    ports:
+      - '80:80'
+      - '81:81'
+      - '443:443'
+    volumes:
+      - ./npm/data:/data
+      - ./npm/letsencrypt:/etc/letsencrypt


### PR DESCRIPTION
## Summary
- add an `npm` service for Nginx Proxy Manager
- document using NPM to proxy to the whiteboard

## Testing
- `docker compose --version` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685391c919e08329a6930968ef00558e