### PR TITLE
Add board clearing and resize features

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,12 +6,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Real-time Whiteboard</title>
   <style>
-    body { margin: 0; }
-    canvas { border: 1px solid #ccc; display: block; margin: 0 auto; }
+    body { margin: 0; display: flex; flex-direction: column; align-items: center; }
+    canvas { border: 1px solid #ccc; }
   </style>
 </head>
 <body>
-  <canvas id="board" width="800" height="600"></canvas>
+  <button id="clear">Clear Board</button>
+  <canvas id="board"></canvas>
   <script src="/socket.io/socket.io.js"></script>
   <script src="script.js"></script>
 </body>

--- a/public/script.js
+++ b/public/script.js
@@ -1,15 +1,27 @@
 const socket = io();
 const canvas = document.getElementById('board');
+const clearBtn = document.getElementById('clear');
 const ctx = canvas.getContext('2d');
 let drawing = false;
+
+resizeCanvas();
+
+function resizeCanvas() {
+  canvas.width = window.innerWidth * 0.8;
+  canvas.height = window.innerHeight * 0.8;
+}
 
 canvas.addEventListener('mousedown', start);
 canvas.addEventListener('mouseup', stop);
 canvas.addEventListener('mouseout', stop);
 canvas.addEventListener('mousemove', draw);
+clearBtn.addEventListener('click', () => clearBoard(true));
 
 socket.on('draw', (data) => {
   drawLine(data.x0, data.y0, data.x1, data.y1, data.color, false);
+});
+socket.on('clear', () => {
+  clearBoard(false);
 });
 
 function start(e) {
@@ -39,7 +51,13 @@ function drawLine(x0, y0, x1, y1, color, emit) {
   socket.emit('draw', { x0, y0, x1, y1, color });
 }
 
+function clearBoard(emit) {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  if (emit) socket.emit('clear');
+}
+
 function getPos(e) {
   const rect = canvas.getBoundingClientRect();
   return [e.clientX - rect.left, e.clientY - rect.top];
 }
+

--- a/server/index.js
+++ b/server/index.js
@@ -14,6 +14,9 @@ io.on('connection', (socket) => {
   socket.on('draw', (data) => {
     socket.broadcast.emit('draw', data);
   });
+  socket.on('clear', () => {
+    socket.broadcast.emit('clear');
+  });
   socket.on('disconnect', () => {
     console.log('user disconnected');
   });


### PR DESCRIPTION
## Summary
- add Clear Board button
- resize whiteboard to 80% of window
- broadcast clear events via socket

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68539225e36083298085a39384a99872