### PR TITLE
Add zoom capability and center whiteboard

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,8 +6,18 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Real-time Whiteboard</title>
   <style>
-    body { margin: 0; display: flex; flex-direction: column; align-items: center; }
-    canvas { border: 1px solid #ccc; }
+    body {
+      margin: 0;
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+    }
+    canvas {
+      border: 1px solid #ccc;
+      transform-origin: center center;
+    }
   </style>
 </head>
 <body>

--- a/public/script.js
+++ b/public/script.js
@@ -3,8 +3,16 @@ const canvas = document.getElementById('board');
 const clearBtn = document.getElementById('clear');
 const ctx = canvas.getContext('2d');
 let drawing = false;
+let lastX = 0,
+  lastY = 0;
+let scale = 1;
 
 resizeCanvas();
+canvas.style.transform = `scale(${scale})`;
+window.addEventListener('resize', () => {
+  resizeCanvas();
+  canvas.style.transform = `scale(${scale})`;
+});
 
 function resizeCanvas() {
   canvas.width = window.innerWidth * 0.8;
@@ -15,6 +23,7 @@ canvas.addEventListener('mousedown', start);
 canvas.addEventListener('mouseup', stop);
 canvas.addEventListener('mouseout', stop);
 canvas.addEventListener('mousemove', draw);
+canvas.addEventListener('wheel', zoom);
 clearBtn.addEventListener('click', () => clearBoard(true));
 
 socket.on('draw', (data) => {
@@ -40,6 +49,13 @@ function draw(e) {
   [lastX, lastY] = [x, y];
 }
 
+function zoom(e) {
+  e.preventDefault();
+  const delta = e.deltaY < 0 ? 1.1 : 0.9;
+  scale = Math.min(5, Math.max(0.2, scale * delta));
+  canvas.style.transform = `scale(${scale})`;
+}
+
 function drawLine(x0, y0, x1, y1, color, emit) {
   ctx.strokeStyle = color;
   ctx.beginPath();
@@ -58,6 +74,9 @@ function clearBoard(emit) {
 
 function getPos(e) {
   const rect = canvas.getBoundingClientRect();
-  return [e.clientX - rect.left, e.clientY - rect.top];
+  return [
+    (e.clientX - rect.left) / scale,
+    (e.clientY - rect.top) / scale,
+  ];
 }
 


### PR DESCRIPTION
## Summary
- center the whiteboard with flexbox
- apply a transform origin to enable scaling
- allow mouse wheel zoom
- keep drawing coordinates in sync when zoomed
- resize canvas and maintain scale on window resize

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68591e2b03208329a2792206405a14d2