### PR TITLE
Add zoom reset option

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,6 +22,7 @@
 </head>
 <body>
   <button id="clear">Clear Board</button>
+  <button id="resetZoom">Reset Zoom</button>
   <canvas id="board"></canvas>
   <script src="/socket.io/socket.io.js"></script>
   <script src="script.js"></script>

--- a/public/script.js
+++ b/public/script.js
@@ -1,6 +1,7 @@
 const socket = io();
 const canvas = document.getElementById('board');
 const clearBtn = document.getElementById('clear');
+const resetZoomBtn = document.getElementById('resetZoom');
 const ctx = canvas.getContext('2d');
 let drawing = false;
 let lastX = 0,
@@ -23,8 +24,9 @@ canvas.addEventListener('mousedown', start);
 canvas.addEventListener('mouseup', stop);
 canvas.addEventListener('mouseout', stop);
 canvas.addEventListener('mousemove', draw);
-canvas.addEventListener('wheel', zoom);
+canvas.addEventListener('wheel', zoom, { passive: false });
 clearBtn.addEventListener('click', () => clearBoard(true));
+resetZoomBtn.addEventListener('click', resetZoom);
 
 socket.on('draw', (data) => {
   drawLine(data.x0, data.y0, data.x1, data.y1, data.color, false);
@@ -54,6 +56,11 @@ function zoom(e) {
   const delta = e.deltaY < 0 ? 1.1 : 0.9;
   scale = Math.min(5, Math.max(0.2, scale * delta));
   canvas.style.transform = `scale(${scale})`;
+}
+
+function resetZoom() {
+  scale = 1;
+  canvas.style.transform = 'scale(1)';
 }
 
 function drawLine(x0, y0, x1, y1, color, emit) {


### PR DESCRIPTION
## Summary
- keep whiteboard zoom limited to canvas element
- add a Reset Zoom button
- disable passive wheel listener so browser zoom doesn't activate

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6859201c472c8329ba2970946869a5e5