### PR TITLE
Improve zoom behavior and switch to SVG

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,7 @@
       align-items: center;
       justify-content: center;
     }
-    canvas {
+    svg#board {
       border: 1px solid #ccc;
       transform-origin: center center;
     }
@@ -23,7 +23,7 @@
 <body>
   <button id="clear">Clear Board</button>
   <button id="resetZoom">Reset Zoom</button>
-  <canvas id="board"></canvas>
+  <svg id="board" xmlns="http://www.w3.org/2000/svg"></svg>
   <script src="/socket.io/socket.io.js"></script>
   <script src="script.js"></script>
 </body>

--- a/public/script.js
+++ b/public/script.js
@@ -1,30 +1,30 @@
 const socket = io();
-const canvas = document.getElementById('board');
+const svg = document.getElementById('board');
 const clearBtn = document.getElementById('clear');
 const resetZoomBtn = document.getElementById('resetZoom');
-const ctx = canvas.getContext('2d');
+const NS = 'http://www.w3.org/2000/svg';
 let drawing = false;
 let lastX = 0,
   lastY = 0;
 let scale = 1;
 
-resizeCanvas();
-canvas.style.transform = `scale(${scale})`;
+resizeBoard();
+svg.style.transform = `scale(${scale})`;
 window.addEventListener('resize', () => {
-  resizeCanvas();
-  canvas.style.transform = `scale(${scale})`;
+  resizeBoard();
+  svg.style.transform = `scale(${scale})`;
 });
 
-function resizeCanvas() {
-  canvas.width = window.innerWidth * 0.8;
-  canvas.height = window.innerHeight * 0.8;
+function resizeBoard() {
+  svg.setAttribute('width', window.innerWidth * 0.8);
+  svg.setAttribute('height', window.innerHeight * 0.8);
 }
 
-canvas.addEventListener('mousedown', start);
-canvas.addEventListener('mouseup', stop);
-canvas.addEventListener('mouseout', stop);
-canvas.addEventListener('mousemove', draw);
-canvas.addEventListener('wheel', zoom, { passive: false });
+svg.addEventListener('mousedown', start);
+svg.addEventListener('mouseup', stop);
+svg.addEventListener('mouseout', stop);
+svg.addEventListener('mousemove', draw);
+svg.addEventListener('wheel', zoom, { passive: false });
 clearBtn.addEventListener('click', () => clearBoard(true));
 resetZoomBtn.addEventListener('click', resetZoom);
 
@@ -54,33 +54,37 @@ function draw(e) {
 function zoom(e) {
   e.preventDefault();
   const delta = e.deltaY < 0 ? 1.1 : 0.9;
-  scale = Math.min(5, Math.max(0.2, scale * delta));
-  canvas.style.transform = `scale(${scale})`;
+  scale = Math.min(5, Math.max(1, scale * delta));
+  svg.style.transform = `scale(${scale})`;
 }
 
 function resetZoom() {
   scale = 1;
-  canvas.style.transform = 'scale(1)';
+  svg.style.transform = 'scale(1)';
 }
 
 function drawLine(x0, y0, x1, y1, color, emit) {
-  ctx.strokeStyle = color;
-  ctx.beginPath();
-  ctx.moveTo(x0, y0);
-  ctx.lineTo(x1, y1);
-  ctx.stroke();
-  ctx.closePath();
+  const line = document.createElementNS(NS, 'line');
+  line.setAttribute('x1', x0);
+  line.setAttribute('y1', y0);
+  line.setAttribute('x2', x1);
+  line.setAttribute('y2', y1);
+  line.setAttribute('stroke', color);
+  line.setAttribute('stroke-linecap', 'round');
+  svg.appendChild(line);
   if (!emit) return;
   socket.emit('draw', { x0, y0, x1, y1, color });
 }
 
 function clearBoard(emit) {
-  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  while (svg.firstChild) {
+    svg.removeChild(svg.firstChild);
+  }
   if (emit) socket.emit('clear');
 }
 
 function getPos(e) {
-  const rect = canvas.getBoundingClientRect();
+  const rect = svg.getBoundingClientRect();
   return [
     (e.clientX - rect.left) / scale,
     (e.clientY - rect.top) / scale,


### PR DESCRIPTION
## Summary
- switch whiteboard to SVG for smoother zooming
- restrict zoom-out to 100% so the page does not zoom out
- ensure zoom only affects the board

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685921f76dfc83298dbcce754a83c68c