### PR TITLE
Fix draw interruption

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -22,7 +22,7 @@ function resizeBoard() {
 
 svg.addEventListener('mousedown', start);
 svg.addEventListener('mouseup', stop);
-svg.addEventListener('mouseout', stop);
+svg.addEventListener('mouseleave', stop);
 svg.addEventListener('mousemove', draw);
 svg.addEventListener('wheel', zoom, { passive: false });
 clearBtn.addEventListener('click', () => clearBoard(true));


### PR DESCRIPTION
## Summary
- fix drawing interruption caused by `mouseout` events by switching to `mouseleave`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `(root)` `npm test` *(fails to find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685923e3eb7c8329b08613b9290d8a4a