### PR TITLE
Improve SVG drawing reliability and move controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Think **[webwhiteboard.com](https://webwhiteboard.com)** but on your own server.
 ## 🛠️ Tech Stack
 
 - **Backend**: Node.js + WebSockets
-- **Frontend**: HTML5 Canvas + JavaScript
+ - **Frontend**: SVG + JavaScript
 - **Containerized**: Docker & Docker Compose
 - **Host OS**: Linux (Debian-based)
 

--- a/public/index.html
+++ b/public/index.html
@@ -10,20 +10,34 @@
       margin: 0;
       height: 100vh;
       display: flex;
+    }
+    #controls {
+      width: 150px;
+      display: flex;
       flex-direction: column;
+      padding: 1em;
+    }
+    #boardContainer {
+      flex-grow: 1;
+      display: flex;
       align-items: center;
       justify-content: center;
     }
     svg#board {
       border: 1px solid #ccc;
       transform-origin: center center;
+      touch-action: none;
     }
   </style>
 </head>
 <body>
-  <button id="clear">Clear Board</button>
-  <button id="resetZoom">Reset Zoom</button>
-  <svg id="board" xmlns="http://www.w3.org/2000/svg"></svg>
+  <div id="controls">
+    <button id="clear">Clear Board</button>
+    <button id="resetZoom">Reset Zoom</button>
+  </div>
+  <div id="boardContainer">
+    <svg id="board" xmlns="http://www.w3.org/2000/svg"></svg>
+  </div>
   <script src="/socket.io/socket.io.js"></script>
   <script src="script.js"></script>
 </body>

--- a/public/script.js
+++ b/public/script.js
@@ -20,10 +20,10 @@ function resizeBoard() {
   svg.setAttribute('height', window.innerHeight * 0.8);
 }
 
-svg.addEventListener('mousedown', start);
-svg.addEventListener('mouseup', stop);
-svg.addEventListener('mouseleave', stop);
-svg.addEventListener('mousemove', draw);
+svg.addEventListener('pointerdown', start);
+svg.addEventListener('pointerup', stop);
+window.addEventListener('pointerup', stop);
+svg.addEventListener('pointermove', draw);
 svg.addEventListener('wheel', zoom, { passive: false });
 clearBtn.addEventListener('click', () => clearBoard(true));
 resetZoomBtn.addEventListener('click', resetZoom);
@@ -37,11 +37,15 @@ socket.on('clear', () => {
 
 function start(e) {
   drawing = true;
+  svg.setPointerCapture(e.pointerId);
   [lastX, lastY] = getPos(e);
 }
 
-function stop() {
+function stop(e) {
   drawing = false;
+  if (e && svg.hasPointerCapture(e.pointerId)) {
+    svg.releasePointerCapture(e.pointerId);
+  }
 }
 
 function draw(e) {
@@ -71,6 +75,7 @@ function drawLine(x0, y0, x1, y1, color, emit) {
   line.setAttribute('y2', y1);
   line.setAttribute('stroke', color);
   line.setAttribute('stroke-linecap', 'round');
+  line.setAttribute('pointer-events', 'none');
   svg.appendChild(line);
   if (!emit) return;
   socket.emit('draw', { x0, y0, x1, y1, color });


### PR DESCRIPTION
## Summary
- make whiteboard controls a left sidebar so they don't scale with the board
- handle drawing with pointer events and pointer capture to avoid interruptions
- update docs for the SVG frontend

## Testing
- `npm test` *(fails: no test specified)*
- `node index.js`

------
https://chatgpt.com/codex/tasks/task_e_685925f026e083299dedd1b0bb1466dc