### PR TITLE
Add context menu and theme toggle

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,12 +11,6 @@
       height: 100vh;
       display: flex;
     }
-    #controls {
-      width: 150px;
-      display: flex;
-      flex-direction: column;
-      padding: 1em;
-    }
     #boardContainer {
       flex-grow: 1;
       display: flex;
@@ -27,17 +21,51 @@
       border: 1px solid #ccc;
       transform-origin: center center;
       touch-action: none;
+      background: #fff;
+    }
+    body.dark {
+      background: #282c33;
+    }
+    body.dark svg#board {
+      background: #3c424d;
+    }
+    #contextMenu {
+      position: absolute;
+      display: none;
+      background: #fff;
+      border: 1px solid #ccc;
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      z-index: 1000;
+    }
+    body.dark #contextMenu {
+      background: #3c424d;
+      color: #fff;
+      border-color: #555;
+    }
+    #contextMenu li {
+      padding: 8px 12px;
+      cursor: pointer;
+    }
+    #contextMenu li:hover {
+      background: rgba(0,0,0,0.1);
+    }
+    body.dark #contextMenu li:hover {
+      background: rgba(255,255,255,0.1);
     }
   </style>
 </head>
 <body>
-  <div id="controls">
-    <button id="clear">Clear Board</button>
-    <button id="resetZoom">Reset Zoom</button>
-  </div>
   <div id="boardContainer">
     <svg id="board" xmlns="http://www.w3.org/2000/svg"></svg>
   </div>
+  <ul id="contextMenu">
+    <li id="contextClear">Clear Board</li>
+    <li id="contextResetZoom">Reset Zoom</li>
+    <li id="themeLight">Light Mode</li>
+    <li id="themeDark">Dark Mode</li>
+  </ul>
   <script src="/socket.io/socket.io.js"></script>
   <script src="script.js"></script>
 </body>

--- a/public/script.js
+++ b/public/script.js
@@ -1,12 +1,18 @@
 const socket = io();
 const svg = document.getElementById('board');
-const clearBtn = document.getElementById('clear');
-const resetZoomBtn = document.getElementById('resetZoom');
+const contextMenu = document.getElementById('contextMenu');
+const clearMenu = document.getElementById('contextClear');
+const resetMenu = document.getElementById('contextResetZoom');
+const themeLight = document.getElementById('themeLight');
+const themeDark = document.getElementById('themeDark');
 const NS = 'http://www.w3.org/2000/svg';
 let drawing = false;
 let lastX = 0,
   lastY = 0;
 let scale = 1;
+
+let currentTheme = 'light';
+setTheme("light");
 
 resizeBoard();
 svg.style.transform = `scale(${scale})`;
@@ -25,8 +31,24 @@ svg.addEventListener('pointerup', stop);
 window.addEventListener('pointerup', stop);
 svg.addEventListener('pointermove', draw);
 svg.addEventListener('wheel', zoom, { passive: false });
-clearBtn.addEventListener('click', () => clearBoard(true));
-resetZoomBtn.addEventListener('click', resetZoom);
+
+svg.addEventListener('contextmenu', (e) => {
+  e.preventDefault();
+  showMenu(e.clientX, e.clientY);
+});
+
+document.addEventListener('click', hideMenu);
+
+themeLight.addEventListener('click', () => setTheme('light'));
+themeDark.addEventListener('click', () => setTheme('dark'));
+clearMenu.addEventListener('click', () => {
+  hideMenu();
+  clearBoard(true);
+});
+resetMenu.addEventListener('click', () => {
+  hideMenu();
+  resetZoom();
+});
 
 socket.on('draw', (data) => {
   drawLine(data.x0, data.y0, data.x1, data.y1, data.color, false);
@@ -34,6 +56,16 @@ socket.on('draw', (data) => {
 socket.on('clear', () => {
   clearBoard(false);
 });
+
+function showMenu(x, y) {
+  contextMenu.style.left = `${x}px`;
+  contextMenu.style.top = `${y}px`;
+  contextMenu.style.display = 'block';
+}
+
+function hideMenu() {
+  contextMenu.style.display = 'none';
+}
 
 function start(e) {
   drawing = true;
@@ -94,5 +126,14 @@ function getPos(e) {
     (e.clientX - rect.left) / scale,
     (e.clientY - rect.top) / scale,
   ];
+}
+
+function setTheme(mode) {
+  currentTheme = mode;
+  if (mode === 'dark') {
+    document.body.classList.add('dark');
+  } else {
+    document.body.classList.remove('dark');
+  }
 }
 


### PR DESCRIPTION
## Summary
- add a custom context menu instead of buttons
- allow switching between light/dark mode
- remove old button markup

## Testing
- `npm test --prefix server`

------
https://chatgpt.com/codex/tasks/task_e_685929a53aac83299588962a3e8c5a67